### PR TITLE
CI and doc changes to address issues #9 and #4

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -6,23 +6,24 @@ on:
   # Both are tracked here to keep legacy and new codes working
   push:
     branches:
-      - "master"
       - "main"
   pull_request:
     branches:
-      - "master"
       - "main"
-  schedule:
-    # Nightly tests run on master by default:
-    #   Scheduled workflows run on the latest commit on the default or base branch.
-    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
-    - cron: "0 0 * * *"
+
+concurrency:
+  # Probably overly cautious group naming.
+  # Commits to develop/master will cancel each other, but PRs will only cancel
+  # commits within the same PR
+  group: "${{ github.ref }}-${{ github.head_ref }}"
+  cancel-in-progress: true
 
 jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,6 +8,9 @@ dependencies:
     # Base depends
   - python
   - pip
+  - numpy
+  - MDAnalysis
+  - nglview
 
     # Testing
   - pytest

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1,13 +1,15 @@
 name: docs
 channels:
+  - conda-forge
+  - defaults
 dependencies:
     # Base depends
   - python
   - pip
   - numpy
   - pytest
-  - MDanalysis
-
+  - mdanalysis
+  - nglview
 
 
     # Pip-only installs

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - numpy
   - pytest
-  - mdanalysis
+  - MDanalysis
 
 
 

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -5,7 +5,6 @@ dependencies:
   - python
   - pip
   - numpy
-  - nglview
   - pytest
 
 

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - numpy
   - pytest
+  - mdanalysis
 
 
 

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -4,6 +4,9 @@ dependencies:
     # Base depends
   - python
   - pip
+  - numpy
+  - nglview
+  - pytest
 
 
 


### PR DESCRIPTION
## Description
This PR makes changes to the test_env.yaml and CI.yaml to support continuous integration.

## Todos
From Issue #9
- [x] test_env.yaml to include the packages needed
- [x] Add fail-fast: false to the strategy section
- [x] Add concurrency groups

From Issue #4 
- [x] fix docs requirement file to allow it to build
- [ ] host updated docs at documentation website

## Questions
- [ ] Is anything else needed for CI to start working?

## Status
- [ ] Ready to go