### PR TITLE
remove pathlib from deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     'pandas',
     'mdanalysis>=2.0.0',
     'pytest',
-    'pathlib',
     'matplotlib',
     'scipy',
     'statsmodels',


### PR DESCRIPTION
As per my comment on conda-forge, by putting pathlib in your pyproject.toml, you're making pip installs pick up pathlib 1.0.1 (i.e. the **old** pathlib). In any case, pathlib is part of the standard library, you shouldn't need to have references to it in your pyproject.toml.